### PR TITLE
proxy-server, fix: mismatch in CURI usage with crud-server

### DIFF
--- a/proxy-server/src/server.js
+++ b/proxy-server/src/server.js
@@ -31,7 +31,7 @@ app.all('/*', (req, res) => {
     return res.status(422).send('id not provided');
   }
 
-  const reqCuri = req.protocol + '://' + req.get('host');
+  const reqCuri = req.get('host');
   // console.log(`reqCuri: ${reqCuri}`);
   const conduit = app.locals.cmap.get(reqCuri);
 


### PR DESCRIPTION
`crud-server/src/routes/api/conduits.js` saves the `curi` field without
the protocol prefix. However, the proxy-server was prefixing the
protocol to the `host` to 'construct' the `reqCuri` in `proxy-server/src/
server.js`. This changeset fixes that mismatch.