### PR TITLE
fix setting of hiddenFormField from request

### DIFF
--- a/proxy-server/src/server.js
+++ b/proxy-server/src/server.js
@@ -52,7 +52,7 @@ app.all('/*', (req, res) => {
       const hff = conduit.hiddenFormField[i];
       let reqHff = undefined;
       if (req.body.records && req.body.records[0].fields[hff.fieldName]) {
-        reqHff = req.body[hff.fieldName];
+        reqHff = req.body.records[0].fields[hff.fieldName];
       };
 
       // This feature is to catch spam bots, so don't


### PR DESCRIPTION
I'm not sure if this is really a bug, but the reason I think there is
something wrong is because the `if` condition checks for something and
then assigns another value seemingly similar to the one that is being
tested.

I hit this bug during testing and was able to proceed only after I made
this change.

The reason why this is not in the same pull request as the test one is
to isolate the scope of the issues ( I already messed up once, I didn't
want another on my hands ).