### PR TITLE
crud-server, test: increase code coverage

### DIFF
--- a/crud-server/src/models/user.js
+++ b/crud-server/src/models/user.js
@@ -97,5 +97,9 @@ module.exports = (db, DataTypes) => {
     return user;
   };
 
+  User.findById = async function (id) {
+    return User.findOne({ where: { id: id } });
+  };
+
   return User;
 };

--- a/crud-server/src/models/user.js
+++ b/crud-server/src/models/user.js
@@ -97,9 +97,5 @@ module.exports = (db, DataTypes) => {
     return user;
   };
 
-  User.findById = async function (id) {
-    return User.findOne({ where: { id: id } });
-  };
-
   return User;
 };

--- a/crud-server/src/routes.test.js
+++ b/crud-server/src/routes.test.js
@@ -240,6 +240,19 @@ describe('Praas REST API', () => {
       expect(User(res).email).to.equal(jake.user.email);
     });
 
+    it('should allow the user to update their information', async function () {
+      const userName = {
+        firstName: 'John',
+        lastName: 'Doe'
+      }
+      const res = await Api()
+                    .put('/user')
+                    .set('Authorization', `Token ${jakeUser.token}`)
+                    .send({ user: userName });
+      expect(res.body.user.firstName).to.equal(userName.firstName);
+      expect(res.body.user.lastName).to.equal(userName.lastName);
+    });
+
     let ctId1, ctId2;
 
     context('testing conduit creation (POST)...', () => {

--- a/crud-server/src/routes.test.js
+++ b/crud-server/src/routes.test.js
@@ -100,6 +100,35 @@ describe('Praas REST API', () => {
         .send();
       expect(res.status).to.equal(422);
     });
+    it('should not authenticate when user credentials are missing', async function () {
+      const user = { ...jake.user };
+      delete user.password;
+      const res = await Api()
+                    .post('/users/login')
+                    .send({ user: user });
+       expect(res.status).to.equal(422);
+       expect(res.body.message).to.equal('Missing credentials');
+    });
+    it('should not authenticate without valid user credentials', async function () {
+      const user = { ...jake.user };
+      user.password = 'jake';
+      const res = await Api()
+                    .post('/users/login')
+                    .send({ user: user });
+       expect(res.status).to.equal(422);
+       expect(res.body).to.have.property('errors');
+       expect(res.body.errors.credentials).to.equal('email or password is invalid');
+    });
+    it('should authenticate with valid user credentials', async function () {
+      const res = await Api()
+                    .post('/users/login')
+                    .send(jake);
+       expect(res.status).to.equal(200);
+       expect(res.body.user).to.have.property('firstName');
+       expect(res.body.user).to.have.property('lastName');
+       expect(res.body.user).to.have.property('email');
+       expect(res.body.user).to.have.property('token');
+    });
   });
 
   context('When authenticated', () => {

--- a/crud-server/src/routes.test.js
+++ b/crud-server/src/routes.test.js
@@ -656,6 +656,22 @@ describe('Praas REST API', () => {
             expect(res.body.error.errors[0].path).to.equal('allowlist');
           });
 
+          it('should not allow invalid IP in allowlist', async function () {
+            const conduit = await helpers.fakeConduit();
+            conduit.allowlist = [{
+              ip: '123.456.789.0',
+              status: 'active'
+            }];
+            const res = await Api()
+              .post(`/conduits`)
+              .set('Authorization', `Token ${jakeUser.token}`)
+              .send({ conduit: conduit });
+            expect(res.status).to.equal(422);
+            expect(res.body.error.name).to.equal('SequelizeValidationError');
+            expect(res.body.error.errors[0].path).to.equal('allowlist');
+            expect(res.body.error.errors[0].message).to.equal('Invalid ip address specified in allowlist');
+          });
+
           it('should allow only valid allowlist properties', async () => {
             const ct = await helpers.fakeConduit();
             ct.allowlist = [{ random: 'random' }];

--- a/crud-server/src/routes.test.js
+++ b/crud-server/src/routes.test.js
@@ -901,6 +901,12 @@ describe('Praas REST API', () => {
           .set('Authorization', `Token ${jakeUser.token}`);
         expect(res.status).to.equal(403);
       });
+      it('should not be able to DELETE non-existant conduits', async () => {
+        const res = await Api()
+          .delete('/conduits/non-existant')
+          .set('Authorization', `Token ${jakeUser.token}`);
+        expect(res.status).to.equal(404);
+      });
     });
   });
 });

--- a/crud-server/src/routes.test.js
+++ b/crud-server/src/routes.test.js
@@ -278,7 +278,10 @@ describe('Praas REST API', () => {
                     .put('/user')
                     .set('Authorization', `Token ${jakeUser.token}`)
                     .send({ user: userName });
+      expect(res.body).to.have.property('user');
+      expect(res.body.user).to.have.property('firstName');
       expect(res.body.user.firstName).to.equal(userName.firstName);
+      expect(res.body.user).to.have.property('lastName');
       expect(res.body.user.lastName).to.equal(userName.lastName);
     });
 

--- a/crud-server/src/routes/api/users.js
+++ b/crud-server/src/routes/api/users.js
@@ -43,7 +43,7 @@ router.post('/users', async (req, res, next) => {
 
 // Update User
 router.put('/user', auth.required, function (req, res, next) {
-  User.findById(req.payload.id).then(function (user) {
+  User.findByPk(req.payload.id).then(function (user) {
     if (!user) return res.sendStatus(401);
 
     const userOptFields = ['firstName', 'lastName', 'password'];


### PR DESCRIPTION
I noticed some easy-to-reach code that were not being covered in the 
test suite.

---

in the process, I also found a bug with the `PUT` method for the user
( update user information ) which would fail because a model method was
~not implemented. I could not find any references to it in the history~
~either ( it could also be that I didn't look hard enough ). I implemented~
~the function and wrote the test for the method.~
missing. this was because Sequelize renamed the `findById` method to
`findByPk` in v5. this was missed during the upgrade from v4 to v5 in
a14cd84.

also while implementing the test for the `PUT` method for the user, I
wondered what would happen if I attempted to change the email of the
user since we use the user's email as the primary key.
while the request processed successfully, the email address field was
not updated which is good. shouldn't we throw some kind of error in
those scenarios though?
I'm not sure what should be done in such scenarios, hence I didn't
include that in the update data for the user. I'm currently only
changing the name of the user. if an error condition is supposed to be
triggered ( and if it is not implemented ), I can add the code for it.

---

### code coverage report

`$ npm run test-rest-with-coverage`

#### before

File            | % Stmts | % Branch | % Funcs | % Lines |
----------------|---------|----------|---------|---------|
All files       |   70.42 |    56.76 |      75 |   70.73 |
 src            |   51.56 |       25 |   16.67 |   51.56 |
  passport.js   |   69.23 |       50 |     100 |   69.23 |
 src/models     |   90.28 |       75 |   96.15 |   89.39 |
  conduit.js    |   86.84 |       75 |     100 |   84.38 |
  user.js       |   92.59 |       75 |    87.5 |   92.59 |
 src/routes/api |   62.91 |       48 |   64.71 |   63.97 |
  conduits.js   |   60.67 |    47.06 |   85.71 |   62.03 |
  users.js      |      66 |       50 |      50 |   67.39 |

#### after

File            | % Stmts | % Branch | % Funcs | % Lines |
----------------|---------|----------|---------|---------|
All files       |   73.67 |    62.16 |    80.7 |   74.24 |
 src            |   53.13 |    33.33 |   16.67 |   53.13 |
  passport.js   |   76.92 |      100 |     100 |   76.92 |
 src/models     |   93.24 |    83.33 |    96.3 |   92.65 |
  conduit.js    |   89.47 |       80 |     100 |    87.5 |
  user.js       |   96.55 |      100 |   88.89 |   96.55 |
 src/routes/api |   68.21 |       54 |   82.35 |   69.85 |
  conduits.js   |    61.8 |       50 |   85.71 |   63.29 |
  users.js      |      80 |    66.67 |    87.5 |   82.61 |

#### unchanged

File            | % Stmts | % Branch | % Funcs | % Lines |
----------------|---------|----------|---------|---------|
 src            |         |          |         |         |
  server.js     |   47.06 |       20 |       0 |   47.06 |
 src/config     |     100 |       75 |     100 |     100 |
  index.js      |     100 |       75 |     100 |     100 |
 src/lib        |      80 |    66.67 |   66.67 |   81.63 |
  helpers.js    |      80 |    66.67 |   66.67 |   81.63 |
 src/models     |         |          |         |         |
  index.js      |     100 |      100 |     100 |     100 |
  system.js     |     100 |      100 |     100 |     100 |
 src/routes     |     100 |    83.33 |     100 |     100 |
  auth.js       |     100 |    83.33 |     100 |     100 |
  index.js      |     100 |      100 |     100 |     100 |
 src/routes/api |         |          |         |         |
  index.js      |   66.67 |       50 |      50 |   63.64 |