### PR TITLE
Fix RACM checkbox

### DIFF
--- a/praas-app-ionic/src/components/Conduit/Form/index.tsx
+++ b/praas-app-ionic/src/components/Conduit/Form/index.tsx
@@ -29,8 +29,17 @@ const ConduitForm: React.FC<Props> = ({ conduit, onSave }) => {
   const onBack = () => {
     history.goBack();
   };
+  const parseRACM = (racm: any) => {
+    const racmList: string[] = [];
+    Object.keys(racm).forEach((key) => {
+      if (racm[key]) {
+        racmList.push(key);
+      }
+    });
+    return racmList;
+  };
   const onSubmit = (values: any) => {
-    onSave(values);
+    onSave({ ...values, racm: parseRACM(values.racm) });
   };
 
   return (

--- a/praas-app-ionic/src/components/Conduit/Form/schema.ts
+++ b/praas-app-ionic/src/components/Conduit/Form/schema.ts
@@ -20,10 +20,25 @@ const conduitSchema = Yup.object().shape({
     )
     .min(0)
     .max(4),
-  racm: Yup.array()
-    .min(1, 'Select atleast on request method')
-    .required('Request methods is required'),
+  racm: Yup.object()
+    .shape({
+      GET: Yup.boolean(),
+      POST: Yup.boolean(),
+      PATCH: Yup.boolean(),
+      DELETE: Yup.boolean(),
+    })
+    .test('customCheckboxTest', '', (racm) => {
+      /* Can be extended later by iterating over the object keys */
+      if (racm.GET || racm.POST || racm.PATCH || racm.DELETE) {
+        return true;
+      }
+      return new Yup.ValidationError(
+        'Select atleast on request method',
+        null,
+        'racm'
+      );
+    }),
+
   description: Yup.string().required('Description is required'),
 });
-
 export default conduitSchema;

--- a/praas-app-ionic/src/components/Form/Checkbox/index.tsx
+++ b/praas-app-ionic/src/components/Form/Checkbox/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { IonCheckbox, IonLabel } from '@ionic/react';
-import { Controller, useFormContext, EventFunction } from 'react-hook-form';
+import { Controller, useFormContext } from 'react-hook-form';
 
 type CheckboxProps = {
   name: string;
@@ -26,13 +26,6 @@ export const CheckBox = ({
   checked,
   onChange,
 }: CheckboxProps) => {
-  const handleChange: EventFunction = ([selected]) => {
-    if (typeof onChange === 'function') {
-      return onChange(selected.detail);
-    } else {
-      return selected.detail.value;
-    }
-  };
   return (
     <>
       <Controller
@@ -41,7 +34,6 @@ export const CheckBox = ({
         value={value}
         defaultValue={checked}
         onChangeName="onIonChange"
-        onChange={handleChange}
       ></Controller>
       <IonLabel className="checkbox__label">{label}</IonLabel>
     </>
@@ -55,13 +47,6 @@ export const CheckBoxGroup = ({
 }: CheckboxGroupProps) => {
   const { getValues } = useFormContext();
   const selected = getValues()[name] || defaultChecked || [];
-  const handleChange = (data: any) => {
-    const updatedList = [...selected];
-    if (data.checked) {
-      return [...updatedList, data.value];
-    }
-    return updatedList.filter((item) => item !== data.value);
-  };
   return (
     <>
       {options.map((option) => {
@@ -69,11 +54,10 @@ export const CheckBoxGroup = ({
         return (
           <CheckBox
             key={option.value}
-            name={name}
+            name={`${name}[${option.value}]`}
             checked={checked}
             value={option.value}
             label={option.label}
-            onChange={handleChange}
           />
         );
       })}


### PR DESCRIPTION
Issue when trying to set the checkbox with a common name as array using react-hook-form. Could be that it is something not expected.
Fixed by storing the checkboxes as object instead of string array, and transform them on submit as array.