### PR TITLE
prass-app: add sort functionality to UI

### DIFF
--- a/praas-app/src/api/praas.js
+++ b/praas-app/src/api/praas.js
@@ -138,8 +138,9 @@ const praas = {
         body: JSON.stringify(data)
       });
     },
-    list() {
-      return afetch('/conduits', {
+    list(sortBy) {
+      const sq = `?sort=${sortBy}`;
+      return afetch(`/conduits${sq}`, {
         method: 'GET',
       });
     },

--- a/praas-app/src/app/pages/conduits/index.js
+++ b/praas-app/src/app/pages/conduits/index.js
@@ -21,6 +21,9 @@ function Conduit(props) {
     cid: undefined
   });
 
+  // eslint-disable-next-line no-unused-vars
+  const [sort, setSort] = useState();
+
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -32,17 +35,24 @@ function Conduit(props) {
     && (mode === 'list' || mode === 'initial') && reason !== 'cancel'
     );
 
+    // const sortBy = 'description:asc';
+    const sortBy = sort ? `description:${sort}` : '';
     if (fetch) {
-      dispatch(listConduits());
+      dispatch(listConduits(sortBy));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [state, user.loggedIn, dispatch]);
+  }, [state, sort, user.loggedIn, dispatch]);
 
   // mode: list|edit|add; reason: cancel|form|refresh; cid: id|undefined
   const viewChanger = (mode, reason, cid, caller) => {
     // view changer called
     setState({ mode, reason, cid, lastSetBy: caller });
     logit('vc', state);
+  };
+
+  const sortView = (sortOrder) => {
+    console.log('>>>> index:', sortOrder);
+    setSort(sortOrder);
   };
 
   // render cycle
@@ -54,7 +64,7 @@ function Conduit(props) {
 
   let view = null;
   if (state.mode.match(/list|initial/)) {
-    view = <ConduitList changeView={viewChanger} />;
+    view = <ConduitList changeView={viewChanger} sortView={sortView} />;
   } else if (state.mode === 'add') {
     view = <CreateConduitForm changeView={viewChanger} />;
   } else if (state.mode === 'edit') {

--- a/praas-app/src/app/pages/conduits/list.js
+++ b/praas-app/src/app/pages/conduits/list.js
@@ -70,6 +70,7 @@ const List = (props) => {
   const clist = useSelector(state => state.conduit.list);
 
   const handleViewChange = () => props.changeView('add', 'form', undefined, 'components/list');
+  const handleSortOrder = (sortOrder) => props.sortView(sortOrder);
 
   const createModal = (conduit) => {
     if (conduit.status === 'inactive') {
@@ -119,6 +120,12 @@ const List = (props) => {
         onClick={handleViewChange}>
         Add conduit
       </button>
+      <button
+        onClick={() => handleSortOrder('Asc')}>List Asc
+      </button>
+      <button
+        onClick={() => handleSortOrder('Desc')}>List Desc
+      </button>
       <table>
         <thead>
           <tr>
@@ -138,6 +145,10 @@ const List = (props) => {
 
 List.propTypes = {
   changeView: PropTypes.func.isRequired,
+};
+
+List.propTypes = {
+  sortView: PropTypes.func.isRequired,
 };
 
 export { List };

--- a/praas-app/src/store/conduit/list.js
+++ b/praas-app/src/store/conduit/list.js
@@ -16,10 +16,10 @@ export const listConduitFailure = (error) => ({
 });
 
 // Async action creators
-export const listConduits = () => {
+export const listConduits = (sortBy) => {
   return (dispatch) => {
     dispatch({ type: LIST_CONDUIT_REQUEST });
-    PraasAPI.conduit.list().then(
+    PraasAPI.conduit.list(sortBy).then(
       (payload) => {
         // console.log('listConduits, success: ', payload.conduits.length);
         dispatch(listConduitSuccess(payload));


### PR DESCRIPTION
- add two buttons in conduit list
- one button to display Description in 'asc'
- another button to display Description in 'desc'
- by default conduit list uses updateAt desc
- when a button is clicked prop value is sent from list.js to conduit/index.js
- the parent gets a prop message there is change in list
- the conduit/index.js gets the prop and changes the state
- then the conduit/index.js send the list prop value to redux store
- the redux sends the list prop value to prass-api
- the prass-api sends the valid query sort param to conduit api
- conduit api sends the list of conduits in the requested sort order